### PR TITLE
build: publish IDA Taskr through HCLI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Keep the package version, HCLI manifest version, and HCLI dependency aligned.
+
+if command -v python3 >/dev/null 2>&1; then
+    if python3 tools/sync_plugin_version.py; then
+        if ! git diff --quiet -- pyproject.toml ida-plugin.json; then
+            git add pyproject.toml ida-plugin.json
+            echo "pre-commit: synced package and HCLI metadata"
+        fi
+    else
+        echo "pre-commit: sync_plugin_version.py failed; aborting commit" >&2
+        exit 1
+    fi
+else
+    echo "pre-commit: python3 not found; skipping version synchronization" >&2
+fi

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,6 +20,31 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    hcli-lint:
+        name: HCLI plugin archive validation
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout plugin source
+              uses: actions/checkout@v5
+              with:
+                  persist-credentials: false
+
+            - name: Validate HCLI metadata
+              run: |
+                  curl -LsSf --retry 3 \
+                    https://github.com/HexRaysSA/ida-hcli/releases/download/v0.18.5/hcli-linux-x86_64-0.18.5 \
+                    -o /tmp/hcli
+                  echo "b35eb351ce9e706709212604f937118643eee861bf4411bc4cac94217245b277  /tmp/hcli" \
+                    | sha256sum --check
+                  chmod 0755 /tmp/hcli
+                  curl -LsSf --retry 3 \
+                    https://raw.githubusercontent.com/HexRaysSA/plugin-repository/3cee9691f72459c5ac75b028c827016e93e58923/plugin-repository.json \
+                    -o /tmp/plugin-repository-v1.json
+                  python3 tools/sync_plugin_version.py --check
+                  python3 tools/build_hcli_archive.py --output /tmp/ida-taskr-hcli.zip
+                  /tmp/hcli plugin --repo /tmp/plugin-repository-v1.json lint .
+                  /tmp/hcli plugin --repo /tmp/plugin-repository-v1.json lint /tmp/ida-taskr-hcli.zip
+
     unit-tests:
         runs-on: ubuntu-24.04
         strategy:
@@ -43,7 +68,7 @@ jobs:
             - name: Install dependencies
               run: |
                   pip install --upgrade pip setuptools wheel uv
-                  uv pip install --system -e .[tests,${{ matrix.qt-framework }}]
+                  uv pip install --system -e ".[tests,${{ matrix.qt-framework }}]"
 
             - name: Python unit tests
               run: |
@@ -74,7 +99,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                   pip install --upgrade pip setuptools wheel
-                  pip install -e .[tests,ci,${{ matrix.qt-framework }}]
+                  pip install -e ".[tests,ci,${{ matrix.qt-framework }}]"
 
             - name: Run Qt Core integration tests
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,117 +1,129 @@
-name: Build and Release
+name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (do not publish to PyPI)'
-        required: false
-        default: true
-        type: boolean
+    push:
+        tags:
+            - "v*"
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag name (for example, v1.0.3)"
+                required: true
+                type: string
+            publish:
+                description: "Create the GitHub release and publish to PyPI"
+                required: true
+                default: false
+                type: boolean
+
+concurrency:
+    group: ${{ github.workflow }}-${{ inputs.tag || github.ref || github.run_id }}
+    cancel-in-progress: true
 
 permissions:
-  contents: write
-  id-token: write
+    contents: write
 
 jobs:
-  build-and-release:
-    name: Build and Release
-    runs-on: ubuntu-latest
+    release:
+        runs-on: ubuntu-latest
+        outputs:
+            publish: ${{ steps.guard.outputs.already == 'false' && (github.event_name == 'push' || inputs.publish == true) }}
+        steps:
+            - name: Resolve release tag
+              id: version
+              env:
+                  REQUESTED_TAG: ${{ inputs.tag }}
+              run: |
+                  if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+                    TAG="$REQUESTED_TAG"
+                  else
+                    TAG="${GITHUB_REF#refs/tags/}"
+                  fi
+                  TAG="${TAG#refs/tags/}"
+                  if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+                    echo "Release tag must use vMAJOR.MINOR.PATCH: $TAG" >&2
+                    exit 1
+                  fi
+                  {
+                    echo "ref=refs/tags/$TAG"
+                    echo "tag=$TAG"
+                    echo "version=${TAG#v}"
+                  } >> "$GITHUB_OUTPUT"
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+            - name: Check for an existing release
+              id: guard
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TAG: ${{ steps.version.outputs.tag }}
+              run: |
+                  if gh release view "$TAG" >/dev/null 2>&1; then
+                    echo "already=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "already=false" >> "$GITHUB_OUTPUT"
+                  fi
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+            - name: Checkout release tag
+              if: ${{ steps.guard.outputs.already == 'false' }}
+              uses: actions/checkout@v5
+              with:
+                  ref: ${{ steps.version.outputs.ref }}
 
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build wheel setuptools
+            - name: Set up Python
+              if: ${{ steps.guard.outputs.already == 'false' }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.10"
 
-      - name: Build Python package
-        run: python -m build
+            - name: Build and validate release artifacts
+              if: ${{ steps.guard.outputs.already == 'false' }}
+              env:
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  python -m pip install --upgrade pip build twine pytest
+                  python tools/sync_plugin_version.py --check
+                  python -m pytest tests/test_hcli_packaging.py tests/test_plugin_manifest.py -v
+                  python -m build
+                  twine check dist/*
+                  python scripts/amalgamate.py --output dist/ida_taskr_amalgamated.py
+                  python tools/build_hcli_archive.py --output "dist/ida-taskr-${VERSION}.zip"
+                  cp "dist/ida-taskr-${VERSION}.zip" dist/ida-taskr-latest.zip
 
-      - name: Extract version from tag
-        id: get_version
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION="dev-$(date +%Y%m%d)"
-          fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Version: ${VERSION}"
+            - name: Create GitHub release
+              if: ${{ steps.guard.outputs.already == 'false' && (github.event_name == 'push' || inputs.publish == true) }}
+              uses: softprops/action-gh-release@v2
+              with:
+                  files: dist/*
+                  tag_name: ${{ steps.version.outputs.tag }}
+                  name: ${{ steps.version.outputs.tag }}
+                  generate_release_notes: true
+                  prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate amalgamated file
-        run: |
-          python scripts/amalgamate.py --output ida_taskr_amalgamated.py
-          echo "Generated ida_taskr_amalgamated.py"
-          wc -l ida_taskr_amalgamated.py
+            - name: Upload PyPI distributions
+              if: ${{ steps.guard.outputs.already == 'false' && (github.event_name == 'push' || inputs.publish == true) }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pypi-distributions
+                  path: |
+                      dist/*.tar.gz
+                      dist/*.whl
+                  if-no-files-found: error
 
-      - name: Verify amalgamated file syntax
-        run: |
-          python -m py_compile ida_taskr_amalgamated.py
-          echo "Syntax check passed"
+    pypi-publish:
+        needs: release
+        if: ${{ needs.release.outputs.publish == 'true' && github.repository_owner == 'mahmoudimus' }}
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+        steps:
+            - name: Download PyPI distributions
+              uses: actions/download-artifact@v4
+              with:
+                  name: pypi-distributions
+                  path: dist
 
-      - name: Create HCLI plugin archive
-        run: |
-          mkdir -p ida-taskr-plugin/src/ida_taskr
-
-          # Copy source files
-          cp -r src/ida_taskr/* ida-taskr-plugin/src/ida_taskr/
-
-          # Copy metadata and documentation
-          cp ida-plugin.json ida-taskr-plugin/
-          cp LICENSE ida-taskr-plugin/
-          cp README.md ida-taskr-plugin/
-
-          # Include amalgamated file
-          cp ida_taskr_amalgamated.py ida-taskr-plugin/
-
-          # Create archive
-          cd ida-taskr-plugin
-          zip -r ../ida-taskr-${{ steps.get_version.outputs.version }}.zip .
-          cd ..
-
-          # Also create a latest version for convenience
-          cp ida-taskr-${{ steps.get_version.outputs.version }}.zip ida-taskr-latest.zip
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ida-taskr-release
-          path: |
-            ida-taskr-*.zip
-            ida_taskr_amalgamated.py
-            dist/
-          retention-days: 30
-
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            ida-taskr-${{ steps.get_version.outputs.version }}.zip
-            ida-taskr-latest.zip
-            ida_taskr_amalgamated.py
-            dist/*.whl
-            dist/*.tar.gz
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          skip-existing: true
+            - name: Publish to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  packages-dir: dist/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,25 @@ pip install -e .[pyside6]  # For IDA Pro 9.2+
 
 **Option 3: IDA Plugin Manager (HCLI)**
 
-Download [`ida-taskr-{version}.zip`](https://github.com/mahmoudimus/ida-taskr/releases/latest) and install via HCLI.
+Install [HCLI](https://hcli.docs.hex-rays.com/) once, then search for and
+install Taskr:
+
+```bash
+hcli plugin search ida-taskr
+hcli plugin install ida-taskr
+```
+
+HCLI installs the plugin under `$IDAUSR/plugins/ida-taskr` and first installs
+the matching `ida-taskr` package into IDA's Python environment. IDA provides
+the Qt bindings, so no PyQt or PySide package is installed separately. Restart
+IDA after the command completes.
+
+For embedding or a non-HCLI installation, install the package with the Python
+interpreter IDA uses:
+
+```bash
+python -m pip install ida-taskr
+```
 
 ## Quick Start
 

--- a/entry_stub.py
+++ b/entry_stub.py
@@ -1,0 +1,3 @@
+"""Load Taskr after HCLI installs its Python distribution."""
+
+from ida_taskr.taskr_plugin import PLUGIN_ENTRY

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -1,23 +1,28 @@
 {
+  "$schema": "https://hcli.docs.hex-rays.com/schemas/ida-plugin.json",
   "IDAMetadataDescriptorVersion": 1,
   "plugin": {
     "name": "ida-taskr",
-    "entryPoint": "src/ida_taskr/__init__.py",
-    "version": "1.0.2",
+    "entryPoint": "entry_stub.py",
+    "version": "1.0.3",
     "description": "A Qt-based multiprocessing framework for IDA Pro that enables parallel computing without blocking the UI. Features simple decorator API (@cpu_task, @parallel, @shared_memory_task), process-based executors, and bidirectional worker IPC.",
     "idaVersions": ">=9.0",
     "license": "MIT",
     "urls": {
-      "repository": "https://github.com/mahmoudimus/ida-taskr"
+      "repository": "https://github.com/mahmoudimus/ida-taskr",
+      "homepage": "https://mahmoudimus.com"
     },
     "authors": [
       {
-        "name": "Mahmoud Abdelkader"
+        "name": "Mahmoud Abdelkader",
+        "email": "m{_no-spam_}@mahmoudimus.com"
       }
     ],
-    "pythonDependencies": [],
+    "pythonDependencies": [
+      "ida-taskr==1.0.3"
+    ],
     "categories": [
-      "analysis",
+      "api-scripting-and-automation",
       "collaboration-and-productivity"
     ],
     "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ida-taskr"
-version = "1.0.2"
+version = "1.0.3"
 description = "A Qt-based multiprocessing framework for IDA Pro parallel computing with simple decorator API"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [
     {name = "Mahmoud Abdelkader"}
@@ -28,7 +29,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Plugins",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/src/ida_taskr/__init__.py
+++ b/src/ida_taskr/__init__.py
@@ -108,4 +108,4 @@ if QT_ASYNCIO_AVAILABLE:
         # QtAsyncio module not available
         pass
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/tests/test_hcli_packaging.py
+++ b/tests/test_hcli_packaging.py
@@ -1,0 +1,78 @@
+"""Regression tests for Taskr's HCLI source-only plugin archive."""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+import runpy
+import zipfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INIT = ROOT / "src" / "ida_taskr" / "__init__.py"
+MANIFEST = ROOT / "ida-plugin.json"
+HCLI_CATEGORIES = {
+    "api-scripting-and-automation",
+    "collaboration-and-productivity",
+    "debugging-and-tracing",
+    "decompilation",
+    "deobfuscation",
+    "disassembly-and-processor-modules",
+    "file-parsers-and-loaders",
+    "integration-with-third-parties-interoperability",
+    "malware-analysis",
+    "other",
+    "ui-ux-and-visualization",
+    "vulnerability-research-and-exploit-development",
+}
+
+
+def _package_version() -> str:
+    tree = ast.parse(INIT.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"could not find __version__ in {INIT}")
+
+
+def _build_hcli_archive(output: pathlib.Path) -> pathlib.Path:
+    namespace = runpy.run_path(str(ROOT / "tools" / "build_hcli_archive.py"))
+    return namespace["build_hcli_archive"](output)
+
+
+def test_manifest_uses_the_plugin_stub_and_exact_distribution() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["plugin"]["entryPoint"] == "entry_stub.py"
+    assert manifest["plugin"]["pythonDependencies"] == [
+        f"ida-taskr=={_package_version()}"
+    ]
+
+
+def test_entry_stub_loads_the_real_plugin_entry() -> None:
+    assert (ROOT / "entry_stub.py").read_text(encoding="utf-8") == (
+        '"""Load Taskr after HCLI installs its Python distribution."""\n\n'
+        "from ida_taskr.taskr_plugin import PLUGIN_ENTRY\n"
+    )
+
+
+def test_manifest_uses_hcli_categories() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert set(manifest["plugin"]["categories"]) <= HCLI_CATEGORIES
+
+
+def test_hcli_archive_contains_only_runtime_plugin_files(tmp_path: pathlib.Path) -> None:
+    archive = _build_hcli_archive(tmp_path / "ida-taskr.zip")
+
+    with zipfile.ZipFile(archive) as package:
+        assert set(package.namelist()) == {
+            "ida-plugin.json",
+            "entry_stub.py",
+            "LICENSE",
+            "README.md",
+        }

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -1,0 +1,49 @@
+"""Keep Taskr's package and HCLI metadata on one version."""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+import re
+import runpy
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INIT = ROOT / "src" / "ida_taskr" / "__init__.py"
+MANIFEST = ROOT / "ida-plugin.json"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def _package_version() -> str:
+    tree = ast.parse(INIT.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"could not find __version__ in {INIT}")
+
+
+def _pyproject_version() -> str:
+    match = re.search(
+        r'^version\s*=\s*"([^"]+)"$', PYPROJECT.read_text(encoding="utf-8"), re.M
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_all_published_versions_match() -> None:
+    version = _package_version()
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert _pyproject_version() == version
+    assert manifest["plugin"]["version"] == version
+    assert manifest["plugin"]["pythonDependencies"] == [f"ida-taskr=={version}"]
+
+
+def test_sync_tool_checks_all_published_versions() -> None:
+    namespace = runpy.run_path(str(ROOT / "tools" / "sync_plugin_version.py"))
+
+    assert namespace["main"](["--check"]) == 0

--- a/tools/build_hcli_archive.py
+++ b/tools/build_hcli_archive.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Build the source-only archive consumed by HCLI and Plugin Manager."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import zipfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PLUGIN_FILES = ("ida-plugin.json", "entry_stub.py", "LICENSE", "README.md")
+
+
+def build_hcli_archive(output: pathlib.Path) -> pathlib.Path:
+    """Write the minimal plugin archive to ``output`` and return its path."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name in PLUGIN_FILES:
+            archive.write(ROOT / name, name)
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    args = parser.parse_args(argv)
+    print(build_hcli_archive(args.output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sync_plugin_version.py
+++ b/tools/sync_plugin_version.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Keep Taskr package and HCLI versions synchronized without importing Qt."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INIT = ROOT / "src" / "ida_taskr" / "__init__.py"
+MANIFEST = ROOT / "ida-plugin.json"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def package_version() -> str:
+    """Read the literal package version without importing IDA or Qt modules."""
+    tree = ast.parse(INIT.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise SystemExit(f"could not find __version__ in {INIT}")
+
+
+def metadata_matches(version: str) -> bool:
+    """Return whether package metadata and HCLI requirements use ``version``."""
+    project = PYPROJECT.read_text(encoding="utf-8")
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    project_version = re.search(r'^version\s*=\s*"([^"]+)"$', project, re.M)
+    return bool(
+        project_version
+        and project_version.group(1) == version
+        and manifest["plugin"]["version"] == version
+        and manifest["plugin"].get("pythonDependencies")
+        == [f"ida-taskr=={version}"]
+    )
+
+
+def sync(version: str) -> None:
+    """Write the package version into pyproject and HCLI manifest metadata."""
+    project = PYPROJECT.read_text(encoding="utf-8")
+    project, count = re.subn(
+        r'^(version\s*=\s*")[^"]+("\s*)$',
+        r"\g<1>" + version + r"\g<2>",
+        project,
+        count=1,
+        flags=re.M,
+    )
+    if count != 1:
+        raise SystemExit("could not locate project version in pyproject.toml")
+    PYPROJECT.write_text(project, encoding="utf-8")
+
+    requirement = f"ida-taskr=={version}"
+    manifest = MANIFEST.read_text(encoding="utf-8")
+    manifest, count = re.subn(
+        r'("version"\s*:\s*")[^"]*(")',
+        r"\g<1>" + version + r"\g<2>",
+        manifest,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit("could not locate manifest version")
+    manifest, count = re.subn(
+        r'("pythonDependencies"\s*:\s*\[\s*")[^"]*(")',
+        r"\g<1>" + requirement + r"\g<2>",
+        manifest,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit("could not locate manifest pythonDependencies")
+    MANIFEST.write_text(manifest, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    version = package_version()
+
+    if metadata_matches(version):
+        return 0
+    if args.check:
+        print(
+            "pyproject.toml or ida-plugin.json does not match "
+            f"ida_taskr.__version__ {version!r}; run: "
+            "python tools/sync_plugin_version.py",
+            file=sys.stderr,
+        )
+        return 1
+    sync(version)
+    print(f"synced package and HCLI metadata to {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- package the HCLI release as a small manifest-plus-stub ZIP; HCLI installs the exact `ida-taskr==1.0.3` distribution before loading the real plugin entry
- add version/requirement synchronization, regression tests, and pinned HCLI lint for both the source manifest and generated ZIP
- retain the amalgamated release asset while separating a tag-gated GitHub release from an OIDC-only PyPI publisher job that receives only wheel/sdist files

## Verification
- `QT_QPA_PLATFORM=offscreen pytest tests/test_imports.py tests/unit -v`: 108 passed, 1 skipped
- packaging/version tests: 6 passed
- wheel and sdist build, `twine check`, amalgamated artifact compilation, HCLI source/ZIP lint, installed-wheel entry-stub check, and `actionlint`

## Release prerequisite
Before tagging `v1.0.3`, configure PyPI Trusted Publishing for `mahmoudimus/ida-taskr` using `.github/workflows/release.yml`. The workflow intentionally has no PyPI token fallback.